### PR TITLE
Limit attachment size

### DIFF
--- a/parsing/parsing.py
+++ b/parsing/parsing.py
@@ -4,6 +4,7 @@ import base64
 import requests
 
 URL_TO_FILE_SERVER = "http://filestorageapi:3200"
+MIN_SIZE_FILE = 1000
 
 
 def send_file_server(file_info, sender):
@@ -41,7 +42,8 @@ def parse_mime_files(mime_message):
             continue
 
         file_info = {"filename": part.get_filename(), "content": part.get_payload(), "type": part.get_content_type()}
-        if len(file_info["filename"]) >= 17 and ".storage_link.txt" == file_info["filename"][-17:]:
+        #Approximation de 1 caractère = 1 octet
+        if len(file_info["content"]) <= MIN_SIZE_FILE:
             continue
 
         send_file_server(file_info, sender)


### PR DESCRIPTION
Je check si la taille de la pièce jointe n'est pas trop faible, ça permet de ne pas stocker des petites pièces jointes et d'envoyer des liens plus lourd que la pj originale (ce qui est contre-productif) mais aussi de ne pas restocker les liens qu'on a déjà généré (la taille passe en dessous de la limite). A voir pour ajuster la taille minimale pour pouvoir stocker un fichier (pour l'instant de 1ko).
J'ai rajouté également un .storage_link avant l'extension pour préparer le dev de l'extension web